### PR TITLE
ESLint Error 수정

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,5 @@
+import nextPlugin from "@next/eslint-plugin-next";
+import reactHooksPlugin from "eslint-plugin-react-hooks";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -10,7 +12,18 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends("next/core-web-vitals"),
+  {
+    plugins: {
+      "@next/next": nextPlugin,
+      "react-hooks": reactHooksPlugin,
+    },
+    rules: {
+      // React Hooks 규칙을 추가합니다.
+      "react-hooks/rules-of-hooks": "error", // Hook 규칙 강제
+      "react-hooks/exhaustive-deps": "warn", // 의존성 배열 검사
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@next/eslint-plugin-next": "^15.1.6",
     "@types/fabric": "^5.3.0",
     "@types/material-colors": "^1.2.3",
     "@types/node": "^20",
@@ -40,6 +41,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^9",
     "eslint-config-next": "15.1.6",
+    "eslint-plugin-react-hooks": "^5.1.0",
     "jsdom": "^26.0.0",
     "postcss": "^8",
     "postcss-import": "^16.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.2.0
+      '@next/eslint-plugin-next':
+        specifier: ^15.1.6
+        version: 15.1.6
       '@types/fabric':
         specifier: ^5.3.0
         version: 5.3.0
@@ -96,6 +99,9 @@ importers:
       eslint-config-next:
         specifier: 15.1.6
         version: 15.1.6(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3)
+      eslint-plugin-react-hooks:
+        specifier: ^5.1.0
+        version: 5.1.0(eslint@9.19.0(jiti@1.21.7))
       jsdom:
         specifier: ^26.0.0
         version: 26.0.0


### PR DESCRIPTION
## 에러 내용
Next.js 15버전을 사용하면서 많은 에러를 겪는 것 같은데 이번 에러는 VSCode 에서 ESLint가 말썽을 부렸습니다.

### 에러 원인
Next.js 버전과 ESLint 버전, 그리고 VSCode의 ESLint 확장 프로그램 버전이 모두 호환되어야 하는데 서로 호환되지 않는 부분이 발생해서 에러가 난 것으로 파악하고 있습니다.

### 에러 메세지
![Image](https://github.com/user-attachments/assets/ae1c19a5-14b0-472b-a5a4-2a20f56bfc80)
![Image](https://github.com/user-attachments/assets/c80b027a-6869-4625-b239-022cd0e95d64)

### 해결 방안
에러메세지에서 요구하는 라이브러리를 설치하고 `eslint.config.mjs` 파일의 코드를 수정해서 해결했습니다.
Next.js 15버전에서는 ESLint의 새로운 플랫 설정을 지원하기 위해 ESLint 설정 방식이 변경되어 `.eslintrc.json` 대신 `eslint.config.mjs` 파일을 사용합니다.
`pnpm add --save-dev @next/eslint-plugin-next` - [@next/eslint-plugin-next](https://www.npmjs.com/package/@next/eslint-plugin-next)
`pnpm add --save-dev eslint-plugin-react-hooks` - [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks)

```jsx
// src/eslint.config.mjs

import nextPlugin from "@next/eslint-plugin-next";
import reactHooksPlugin from "eslint-plugin-react-hooks";
import { dirname } from "path";
import { fileURLToPath } from "url";
import { FlatCompat } from "@eslint/eslintrc";

const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);

const compat = new FlatCompat({
  baseDirectory: __dirname,
});

const eslintConfig = [
  ...compat.extends("next/core-web-vitals"),
  {
    plugins: {
      "@next/next": nextPlugin,
      "react-hooks": reactHooksPlugin,
    },
    rules: {
      // React Hooks 규칙을 추가합니다.
      "react-hooks/rules-of-hooks": "error", // Hook 규칙 강제
      "react-hooks/exhaustive-deps": "warn", // 의존성 배열 검사
    },
  },
];

export default eslintConfig;
```