### PR TITLE
에디터 이미지 추가 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## 캔바 클론
+### 사용기술
+- Next.js 15
+- pnpm
+- shadcn-ui
+- tanstack-query
+- fabric.js
+- hono
+- zod
+- auth.js
+- drizzle ORM
+- supabase( PostgreSQL )
+
 ### pnpm
 
 프로젝트 생성

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,7 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals"),
+  ...compat.extends("next/core-web-vitals", "prettier"),
   {
     plugins: {
       "@next/next": nextPlugin,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com"
+      }
+    ]
+  }
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hono/zod-validator": "^0.4.2",
     "@radix-ui/react-dropdown-menu": "^2.1.5",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-scroll-area": "^1.2.2",
@@ -16,9 +17,11 @@
     "@radix-ui/react-slider": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.7",
+    "@tanstack/react-query": "^5.66.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "fabric": "5.3.0-browser",
+    "hono": "^4.6.20",
     "lucide-react": "^0.474.0",
     "material-colors": "^1.2.6",
     "next": "15.1.6",
@@ -27,7 +30,9 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.4.0",
     "tailwind-merge": "^3.0.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "unsplash-js": "^7.0.19",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hono/zod-validator':
+        specifier: ^0.4.2
+        version: 0.4.2(hono@4.6.20)(zod@3.24.1)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.5
         version: 2.1.5(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -29,6 +32,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.7
         version: 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.8))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-query':
+        specifier: ^5.66.0
+        version: 5.66.0(react@19.0.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -38,6 +44,9 @@ importers:
       fabric:
         specifier: 5.3.0-browser
         version: 5.3.0-browser
+      hono:
+        specifier: ^4.6.20
+        version: 4.6.20
       lucide-react:
         specifier: ^0.474.0
         version: 0.474.0(react@19.0.0)
@@ -65,6 +74,12 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.17)
+      unsplash-js:
+        specifier: ^7.0.19
+        version: 7.0.19
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -227,6 +242,12 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@hono/zod-validator@0.4.2':
+    resolution: {integrity: sha512-1rrlBg+EpDPhzOV4hT9pxr5+xDVmKuz6YJl+la7VCwK6ass5ldyKm5fD+umJdV2zhHD6jROoCCv8NbTwyfhT0g==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.19.1
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -812,6 +833,14 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tanstack/query-core@5.66.0':
+    resolution: {integrity: sha512-J+JeBtthiKxrpzUu7rfIPDzhscXF2p5zE/hVdrqkACBP8Yu0M96mwJ5m/8cPPYQE9aRNvXztXHlNwIh4FEeMZw==}
+
+  '@tanstack/react-query@5.66.0':
+    resolution: {integrity: sha512-z3sYixFQJe8hndFnXgWu7C79ctL+pI0KAelYyW+khaNJ1m22lWrhJU2QrsTcRKMuVPtoZvfBYrTStIdKo+x0Xw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1517,6 +1546,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hono@4.6.20:
+    resolution: {integrity: sha512-5qfNQeaIptMaJKyoJ6N/q4gIq0DBp2FCRaLNuUI3LlJKL4S37DY/rLL1uAxA4wrPB39tJ3s+f7kgI79O4ScSug==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -2432,6 +2465,10 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
+  unsplash-js@7.0.19:
+    resolution: {integrity: sha512-j6qT2floy5Q2g2d939FJpwey1yw/GpQecFiSouyJtsHQPj3oqmqq3K4rI+GF8vU1zwGCT7ZwIGQd2dtCQLjYJw==}
+    engines: {node: '>=10'}
+
   update-browserslist-db@1.1.2:
     resolution: {integrity: sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==}
     hasBin: true
@@ -2545,6 +2582,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -2648,6 +2688,11 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@hono/zod-validator@0.4.2(hono@4.6.20)(zod@3.24.1)':
+    dependencies:
+      hono: 4.6.20
+      zod: 3.24.1
 
   '@humanfs/core@0.19.1': {}
 
@@ -3146,6 +3191,13 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.66.0': {}
+
+  '@tanstack/react-query@5.66.0(react@19.0.0)':
+    dependencies:
+      '@tanstack/query-core': 5.66.0
+      react: 19.0.0
 
   '@types/estree@1.0.6': {}
 
@@ -4048,6 +4100,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hono@4.6.20: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -5026,6 +5080,8 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  unsplash-js@7.0.19: {}
+
   update-browserslist-db@1.1.2(browserslist@4.24.4):
     dependencies:
       browserslist: 4.24.4
@@ -5137,3 +5193,5 @@ snapshots:
   yaml@2.7.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.24.1: {}

--- a/src/app/api/[[...route]]/images.ts
+++ b/src/app/api/[[...route]]/images.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+
+import { unsplash } from "@/lib/unsplash";
+
+const DEFAULT_COUNT = 50;
+const DEFAULT_COLLECTION_IDS = ["317099"];
+
+const app = new Hono()
+    .get("/", async (context) => {
+        const images = await unsplash.photos.getRandom({
+            collectionIds: DEFAULT_COLLECTION_IDS,
+            count: DEFAULT_COUNT,
+        })
+
+        if (images.errors) {
+            return context.json({ error: "Something went wrong" }, 400);
+        }
+
+        let response = images.response;
+
+        if (!Array.isArray(response)) {
+            response = [response];
+        }
+
+        return context.json({ data: response });
+    })
+
+export default app;

--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -1,0 +1,16 @@
+import { Hono } from "hono";
+import { handle } from "hono/vercel";
+
+import images from "./images";
+
+// Revert to "edge" if planning on running on the edge
+export const runtime = "nodejs";
+
+const app = new Hono().basePath("/api");
+
+const routes = app.route("/images", images);
+
+// 기존 API를 덮어씁니다.
+export const GET = handle(app);
+
+export type AppType = typeof routes;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { Providers } from "@/components/provider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -13,7 +14,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/src/components/provider.tsx
+++ b/src/components/provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { QueryProvider } from "@/components/query-provider";
+
+interface ProvidersProps {
+  children: React.ReactNode;
+}
+
+export const Providers = ({ children }: ProvidersProps) => {
+  return <QueryProvider>{children}</QueryProvider>;
+};

--- a/src/components/query-provider.tsx
+++ b/src/components/query-provider.tsx
@@ -1,0 +1,49 @@
+// In Next.js, this file would be called: app/providers.tsx
+"use client";
+
+// Since QueryClientProvider relies on useContext under the hood, we have to put 'use client' on top
+import {
+  isServer,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // With SSR, we usually want to set some default staleTime
+        // above 0 to avoid refetching immediately on the client
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  // NOTE: Avoid useState when initializing the query client if you don't
+  //       have a suspense boundary between this and the code that may
+  //       suspend because React will throw away the client on the initial
+  //       render if it suspends and there is no boundary
+  const queryClient = getQueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -12,6 +12,7 @@ import { Sidebar } from "@/features/editor/components/sidebar";
 import { FontSidebar } from "@/features/editor/components/font-sidebar";
 import { TextSidebar } from "@/features/editor/components/text-sidebar";
 import { ShapeSidebar } from "@/features/editor/components/shape-sidebar";
+import { ImageSidebar } from "@/features/editor/components/image-sidebar";
 import { OpacitySidebar } from "@/features/editor/components/opacity-sidebar";
 import { FillColorSidebar } from "@/features/editor/components/fill-color-sidebar";
 import { StrokeColorSidebar } from "@/features/editor/components/stroke-color-sidebar";
@@ -116,6 +117,12 @@ export const Editor = () => {
         />
 
         <FontSidebar
+          editor={editor}
+          activeTool={activeTool}
+          onChangeActiveTool={onChangeActiveTool}
+        />
+
+        <ImageSidebar
           editor={editor}
           activeTool={activeTool}
           onChangeActiveTool={onChangeActiveTool}

--- a/src/features/editor/components/image-sidebar.tsx
+++ b/src/features/editor/components/image-sidebar.tsx
@@ -1,0 +1,92 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+import { useGetImages } from "@/features/images/api/use-get-images";
+
+import { ToolSidebarClose } from "@/features/editor/components/tool-sidebar-close";
+import { ToolSidebarHeader } from "@/features/editor/components/tool-sidebar-header";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+import { ActiveTool, Editor } from "@/features/editor/types";
+import { AlertTriangleIcon, LoaderIcon } from "lucide-react";
+
+interface ImageSidebarProps {
+  editor: Editor | undefined;
+  activeTool: ActiveTool;
+  onChangeActiveTool: (tool: ActiveTool) => void;
+}
+
+export const ImageSidebar = ({
+  editor,
+  activeTool,
+  onChangeActiveTool,
+}: ImageSidebarProps) => {
+  const { data, isLoading, isError } = useGetImages();
+
+  const onClose = () => {
+    onChangeActiveTool("select");
+  };
+
+  return (
+    <aside
+      className={cn(
+        "relative z-[40] flex h-full w-[360px] flex-col border-r bg-white",
+        activeTool === "images" ? "visible" : "hidden",
+      )}
+    >
+      <ToolSidebarHeader
+        title="Images"
+        description="Add images to your canvas"
+      />
+
+      {isLoading && (
+        <div className="flex flex-1 items-center justify-center">
+          <LoaderIcon className="size-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-y-4">
+          <AlertTriangleIcon className="size-4 text-muted-foreground" />
+          <p className="text-xs text-muted-foreground">Fail to fetch images</p>
+        </div>
+      )}
+
+      <ScrollArea>
+        <div className="p-4">
+          <div className="grid grid-cols-2 gap-4">
+            {data &&
+              data.map((image) => {
+                return (
+                  <button
+                    key={image.id}
+                    onClick={() => editor?.addImage(image.urls.regular)}
+                    className="group relative h-[100px] w-full overflow-hidden rounded-sm border bg-muted transition hover:opacity-75"
+                  >
+                    <Image
+                      fill
+                      src={image.urls.small}
+                      alt={image.alt_description || "Image"}
+                      className="object-cover"
+                    />
+                    <Link
+                      target="_blank"
+                      href={image.links.html}
+                      className="absolute bottom-0 left-0 w-full truncate bg-black/50 p-1 text-left text-[10px] text-white opacity-0 transition hover:underline group-hover:opacity-100"
+                    >
+                      {image.user.name}
+                    </Link>
+                  </button>
+                );
+              })}
+          </div>
+        </div>
+      </ScrollArea>
+
+      <ToolSidebarClose onClick={onClose} />
+    </aside>
+  );
+};

--- a/src/features/editor/hooks/use-editor.ts
+++ b/src/features/editor/hooks/use-editor.ts
@@ -63,6 +63,18 @@ const buildEditor = ({
   };
 
   return {
+    addImage: (value: string) => {
+      fabric.Image.fromURL(value, (image) => {
+        const workspace = getWorkspace();
+
+        image.scaleToWidth(workspace?.width || 0);
+        image.scaleToHeight(workspace?.height || 0);
+
+        addToCanvas(image);
+      }, {
+        crossOrigin: "anonymous"
+      })
+    },
     delete: () => {
       canvas.getActiveObjects().forEach(object => canvas.remove(object))
       canvas.discardActiveObject();

--- a/src/features/editor/types.ts
+++ b/src/features/editor/types.ts
@@ -157,6 +157,7 @@ export type BuildEditorProps = {
 
 // 에디터에서 수행하는 이벤트 타입
 export interface Editor {
+  addImage: (value: string) => void;
   delete: () => void;
   changeFontSize: (value: number) => void;
   changeTextAlign: (value: string) => void;

--- a/src/features/images/api/use-get-images.ts
+++ b/src/features/images/api/use-get-images.ts
@@ -1,0 +1,21 @@
+
+import { client } from "@/lib/hono";
+import { useQuery } from "@tanstack/react-query";
+
+export const useGetImages = () => {
+    const query = useQuery({
+        queryKey: ["images"],
+        queryFn: async () => {
+            const response = await client.api.images.$get();
+
+            if (!response.ok) {
+                throw new Error("Failed to fetch images");
+            }
+
+            const { data } = await response.json();
+            return data;
+        }
+    });
+
+    return query;
+};

--- a/src/lib/hono.ts
+++ b/src/lib/hono.ts
@@ -1,0 +1,6 @@
+import { hc } from "hono/client";
+
+import { AppType } from "@/app/api/[[...route]]/route";
+
+export const client = hc<AppType>("/");
+

--- a/src/lib/unsplash.ts
+++ b/src/lib/unsplash.ts
@@ -1,0 +1,6 @@
+import { createApi } from "unsplash-js";
+
+export const unsplash = createApi({
+    accessKey: process.env.NEXT_PUBLIC_UNSPLASH_ACCESS_KEY!,
+    fetch: fetch
+})


### PR DESCRIPTION
## 이미지 추가

### 화면
![Image](https://github.com/user-attachments/assets/60c0c26e-d402-44e3-a02b-7166720cff1b)

### 작업 내역
- [x] Unsplash API 사용해서 Random Image 50장 불러오기
- [x] 이미지 클릭 시 Canvas에 이미지 객체로 추가되도록 설정
- [x] Tanstack Query Provider 코드 추가
- [x] unsplash-js 로 Unsplash에서 불러온 이미지 쉽게 적용
- [x] hono 사용을 위한 기본 코드 추가
- [x] @hono/zod-validator 를 추가

### [Hono with Zod](https://hono.dev/docs/guides/validation)
Hono는 Zod와 함께 사용이 가능하며 Hono와 함께 Zod를 사용하면 API 요청 및 응답의 데이터 구조를 정확하게 정의하고 검증할 수 있습니다.

### Hono Tip - `src/lib/hono.ts`
이전 버전 Hono는 상대경로로 hc(hono client) 를 사용할 수 없었는데 이번에는 상대경로로 설정을 해야 제대로 api call 이 가능했습니다.

### 환경변수
`NEXT_PUBLIC_UNSPLASH_ACCESS_KEY`