### PR TITLE
AI 이미지 생성 오류 수정

### DIFF
--- a/src/app/api/[[...route]]/ai.ts
+++ b/src/app/api/[[...route]]/ai.ts
@@ -12,8 +12,7 @@ const app = new Hono().post(
     const { prompt } = context.req.valid("json");
 
     const input = {
-      prompt:
-        'black forest gateau cake spelling out the words "FLUX SCHNELL", tasty, food photography, dynamic shot',
+      prompt: prompt,
       go_fast: true,
       megapixels: "1",
       num_outputs: 1,
@@ -26,8 +25,19 @@ const app = new Hono().post(
     const output = await replicate.run("black-forest-labs/flux-schnell", {
       input,
     });
+    console.log({ output });
 
     const response = output as Array<string>;
+
+    // 이미지를 파일형태로 반환하고 싶을때 사용할 코드
+    // 이때 lib/relicate.ts 에서 useFileOutput:false를 true로 변경하던지 삭제해야 합니다.
+    /* const response = output as ReadableStream[];
+    const reader = response[0].getReader();
+    const result = await reader.read();
+    const imageData = result.value;
+    // Blob으로 변환하고 URL 생성
+    const blob = new Blob([imageData], { type: "image/webp" });
+    const imageUrl = URL.createObjectURL(blob); */
 
     return context.json({ data: response[0] });
   },

--- a/src/lib/replicate.ts
+++ b/src/lib/replicate.ts
@@ -2,4 +2,5 @@ import Replicate from "replicate";
 
 export const replicate = new Replicate({
   auth: process.env.REPLICATE_API_TOKEN,
+  useFileOutput: false,
 });


### PR DESCRIPTION
### 오류 원인
Replicate 에서 응답하는 기본값이 URL 이 아닌 ReadableStream으로 변경됨.
### 변경된 이유
일반적으로 이미지 생성이나 처리와 같은 작업은 작업의 결과는 대개 이미지 데이터 자체입니다.
따라서 직접 데이터를 반환함으로써 추가적인 네트워크 요청을 줄일 수 있고 데이터의 일관성을 유지할 수 있습니다.
### 해결 방법
replicate 옵션을 추가로 설정해 `useFileOutPut:false`로 설정해 URL 형태로 데이터를 받도록 설정을 수정
응답 형태 - `['https://replicate.delivery/xezq/PTfFAasZvLWcaS6ZyIzYvS2w0WjQ4VKz9ydeuQggzxDCytMUA/out-0.webp']`

하지만 파일 그자체로 처리하는 방식 또한 사용해 보기 위해 코드를 추가하고 주석처리를 하고 설명을 추가함

```tsx
    // 이미지를 파일형태로 반환하고 싶을때 사용할 코드
    // 이때 lib/relicate.ts 에서 useFileOutput:false를 true로 변경하던지 삭제해야 합니다.
    const response = output as ReadableStream[];
    const reader = response[0].getReader();
    const result = await reader.read();
    const imageData = result.value;
    // Blob으로 변환하고 URL 생성
    const blob = new Blob([imageData], { type: "image/webp" });
    const imageUrl = URL.createObjectURL(blob);
```