### PR TITLE
객체 복사 기능 추가

### DIFF
--- a/src/features/editor/components/toolbar.tsx
+++ b/src/features/editor/components/toolbar.tsx
@@ -34,6 +34,7 @@ import {
   ChevronDownIcon,
   TrashIcon,
   SquareSplitHorizontalIcon,
+  CopyIcon,
 } from "lucide-react";
 
 interface ToolbarProps {
@@ -419,6 +420,25 @@ export const Toolbar = ({
             )}
           >
             <RxTransparencyGrid />
+          </Button>
+        </Hint>
+      </div>
+
+      <div className="flex h-full items-center justify-center">
+        <Hint label="Duplicate" side="bottom" sideOffset={5}>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => {
+              editor?.onCopy();
+              editor?.onPaste();
+            }}
+            className={cn(
+              activeTool === "opacity" && "bg-gray-100",
+              "[&_svg]:size-4",
+            )}
+          >
+            <CopyIcon />
           </Button>
         </Hint>
       </div>

--- a/src/features/editor/hooks/use-clipboard.ts
+++ b/src/features/editor/hooks/use-clipboard.ts
@@ -1,0 +1,48 @@
+import { fabric } from "fabric";
+import { useCallback, useRef } from "react";
+
+interface UseClipboardProps {
+  canvas: fabric.Canvas | null;
+}
+
+export const useClipboard = ({ canvas }: UseClipboardProps) => {
+  const clipboard = useRef<any>(null);
+
+  const copy = useCallback(() => {
+    canvas?.getActiveObject()?.clone((cloned: any) => {
+      clipboard.current = cloned;
+    });
+  }, [canvas]);
+
+  const paste = useCallback(() => {
+    if (!clipboard.current) return;
+
+    clipboard.current.clone((clonedObj: any) => {
+      canvas?.discardActiveObject();
+
+      // 복제된 객체는 원본과 구별하기위해 살짝 왼쪽에 생성
+      clonedObj.set({
+        left: clonedObj.left + 10,
+        top: clonedObj.top + 10,
+        evented: true,
+      });
+
+      if (clonedObj.type === "activeSelection") {
+        clonedObj.canvas = canvas;
+        clonedObj.forEachObject((object: any) => {
+          canvas?.add(object);
+        });
+        clonedObj.setCoords();
+      } else {
+        canvas?.add(clonedObj);
+      }
+
+      clipboard.current.left += 10;
+      clipboard.current.top += 10;
+      canvas?.setActiveObject(clonedObj);
+      canvas?.requestRenderAll();
+    });
+  }, [canvas]);
+
+  return { copy, paste };
+};

--- a/src/features/editor/hooks/use-editor.ts
+++ b/src/features/editor/hooks/use-editor.ts
@@ -5,6 +5,7 @@ import { createFilter, isTextType } from "@/features/editor/utils";
 
 import { useAutoResize } from "@/features/editor/hooks/use-auto-resize";
 import { useCanvasEvents } from "@/features/editor/hooks/use-canvas-events";
+import { useClipboard } from "@/features/editor/hooks/use-clipboard";
 
 import {
   Editor,
@@ -26,6 +27,8 @@ import {
 
 // Shape 추가 기능 담당
 const buildEditor = ({
+  copy,
+  paste,
   canvas,
   fillColor,
   fontFamily,
@@ -62,6 +65,8 @@ const buildEditor = ({
   };
 
   return {
+    onCopy: () => copy(),
+    onPaste: () => paste(),
     changeImageFilter: (value: string) => {
       const objects = canvas.getActiveObjects();
       objects.forEach((object) => {
@@ -522,6 +527,8 @@ export const useEditor = ({ clearSelectionCallback }: EditorHookProps) => {
   const [strokeDashArray, setStrokeDashArray] =
     useState<number[]>(STROKE_DASH_ARRAY);
 
+  const { copy, paste } = useClipboard({ canvas });
+
   useAutoResize({
     canvas,
     container,
@@ -532,6 +539,8 @@ export const useEditor = ({ clearSelectionCallback }: EditorHookProps) => {
   const editor = useMemo(() => {
     if (canvas) {
       return buildEditor({
+        copy,
+        paste,
         canvas,
         fillColor,
         strokeColor,
@@ -549,6 +558,8 @@ export const useEditor = ({ clearSelectionCallback }: EditorHookProps) => {
 
     return undefined;
   }, [
+    copy,
+    paste,
     canvas,
     fillColor,
     strokeColor,

--- a/src/features/editor/types.ts
+++ b/src/features/editor/types.ts
@@ -168,6 +168,8 @@ export interface EditorHookProps {
 }
 
 export type BuildEditorProps = {
+  copy: () => void;
+  paste: () => void;
   canvas: fabric.Canvas;
   fillColor: string;
   strokeColor: string;
@@ -184,6 +186,8 @@ export type BuildEditorProps = {
 
 // 에디터에서 수행하는 이벤트 타입
 export interface Editor {
+  onCopy: () => void;
+  onPaste: () => void;
   changeImageFilter: (value: string) => void;
   addImage: (value: string) => void;
   delete: () => void;


### PR DESCRIPTION
## 객체 복사
### 화면
![Image](https://github.com/user-attachments/assets/baec190f-f50b-42e0-9b96-088c3fdbd640)

### 작업 내역
- [x] 객체 클릭 시 나타나는 Toolbar에 객체 복사 버튼 추가
- [x] 객체 복사 버튼 클릭시 원본보다 왼쪽아래로 복사된 객체가 생성