### PR TITLE
일반 로그인/회원가입 구현

### DIFF
--- a/drizzle/0001_demonic_vin_gonzales.sql
+++ b/drizzle/0001_demonic_vin_gonzales.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "password" text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,328 @@
+{
+  "id": "e30f10d9-1657-4ff9-985e-db10e3495a9f",
+  "prevId": "3c340975-32dc-4e4b-8594-e53f78def9c0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_state": {
+          "name": "session_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authenticator": {
+      "name": "authenticator",
+      "schema": "",
+      "columns": {
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerAccountId": {
+          "name": "providerAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialPublicKey": {
+          "name": "credentialPublicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialDeviceType": {
+          "name": "credentialDeviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentialBackedUp": {
+          "name": "credentialBackedUp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "authenticator_userId_user_id_fk": {
+          "name": "authenticator_userId_user_id_fk",
+          "tableFrom": "authenticator",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "authenticator_credentialID_unique": {
+          "name": "authenticator_credentialID_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credentialID"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "sessionToken": {
+          "name": "sessionToken",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verificationToken": {
+      "name": "verificationToken",
+      "schema": "",
+      "columns": {
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1739306434653,
       "tag": "0000_strong_sway",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1739475820034,
+      "tag": "0001_demonic_vin_gonzales",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-tooltip": "^1.1.7",
     "@tanstack/react-query": "^5.66.0",
     "@uploadthing/react": "^7.1.5",
+    "bcryptjs": "^3.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.39.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@uploadthing/react':
         specifier: ^7.1.5
         version: 7.1.5(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(uploadthing@7.4.4(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(tailwindcss@3.4.17))
+      bcryptjs:
+        specifier: ^3.0.0
+        version: 3.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1449,6 +1452,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bcryptjs@3.0.0:
+    resolution: {integrity: sha512-Q2vVGpGC7B7m9wggpcA5lq4OYR5OS1nrXoUpnH9MmogXU8HpxzKg63uxtCrLebY5v/y3o0r7JcGCpR/vTGGn7A==}
+    hasBin: true
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -4471,6 +4478,8 @@ snapshots:
 
   base64-js@1.5.1:
     optional: true
+
+  bcryptjs@3.0.0: {}
 
   binary-extensions@2.3.0: {}
 

--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -3,13 +3,17 @@ import { handle } from "hono/vercel";
 
 import ai from "./ai";
 import images from "./images";
+import users from "./users";
 
 // Revert to "edge" if planning on running on the edge
 export const runtime = "nodejs";
 
 const app = new Hono().basePath("/api");
 
-const routes = app.route("/ai", ai).route("/images", images);
+const routes = app
+  .route("/ai", ai)
+  .route("/images", images)
+  .route("/users", users);
 
 // 기존 API를 덮어씁니다.
 export const GET = handle(app);

--- a/src/app/api/[[...route]]/users.ts
+++ b/src/app/api/[[...route]]/users.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { Hono } from "hono";
+import bcrypt from "bcryptjs";
+import { eq } from "drizzle-orm";
+import { zValidator } from "@hono/zod-validator";
+
+import { db } from "@/db/drizzle";
+import { users } from "@/db/schema";
+
+const app = new Hono().post(
+  "/",
+  zValidator(
+    "json",
+    z.object({
+      name: z.string(),
+      email: z.string(),
+      password: z.string().min(3).max(20),
+    }),
+  ),
+  async (context) => {
+    const { name, email, password } = context.req.valid("json");
+
+    const hashedPassword = await bcrypt.hash(password, 12);
+
+    // 이메일 중복 체크
+    const query = await db.select().from(users).where(eq(users.email, email));
+
+    if (query[0]) {
+      return context.json({ error: "Email already in use" }, 400);
+    }
+
+    await db.insert(users).values({
+      email,
+      name,
+      password: hashedPassword,
+    });
+
+    return context.json(null, 200);
+  },
+);
+
+export default app;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,7 @@
+import { auth } from "@/auth";
+
 export default async function Home() {
-  return <div>Main Page</div>;
+  const session = await auth();
+
+  return <div>{JSON.stringify(session)}</div>;
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,17 +1,86 @@
+import { z } from "zod";
+import bcrypt from "bcryptjs";
 import NextAuth from "next-auth";
+import { eq } from "drizzle-orm";
+
+import { JWT } from "next-auth/jwt";
 import Github from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
+import Credentials from "next-auth/providers/credentials";
 
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 
 import { db } from "@/db/drizzle";
+import { users } from "@/db/schema";
+
+const CredentialsSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+});
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    id: string | undefined;
+  }
+}
 
 // usersTable, accountsTable, sessionsTable, verificationTokenTable 따로 지정하지 않고 기본값으로 적용
 export const { handlers, signIn, signOut, auth } = NextAuth({
   adapter: DrizzleAdapter(db),
-  providers: [Github, Google],
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: "Email", type: "email" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(credentials) {
+        const validatedFields = CredentialsSchema.safeParse(credentials);
+
+        if (!validatedFields.success) return null;
+
+        const { email, password } = validatedFields.data;
+
+        // 입력된 이메일에 해당하는 유저 찾기
+        const query = await db
+          .select()
+          .from(users)
+          .where(eq(users.email, email));
+
+        const user = query[0];
+
+        if (!user || !user.password) return null;
+
+        // 입력된 비밀번호 검증
+        const passwordMatch = await bcrypt.compare(password, user.password);
+
+        if (!passwordMatch) return null;
+
+        return user;
+      },
+    }),
+    Github,
+    Google,
+  ],
   pages: {
     signIn: "/sign-in",
     error: "/sign-in",
+  },
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    session({ session, token }) {
+      if (token.id) {
+        session.user.id = token.id;
+      }
+      return session;
+    },
+    jwt({ token, user }) {
+      if (user) {
+        token.id = user.id;
+      }
+
+      return token;
+    },
   },
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -17,6 +17,7 @@ export const users = pgTable("user", {
   email: text("email").unique(),
   emailVerified: timestamp("emailVerified", { mode: "date" }),
   image: text("image"),
+  password: text("password"),
 });
 
 export const accounts = pgTable(

--- a/src/features/auth/components/sign-in-card.tsx
+++ b/src/features/auth/components/sign-in-card.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import { useState, useTransition } from "react";
 import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
 
 import {
   Card,
@@ -10,14 +12,39 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 
 import { FaGithub as GithubIcon } from "react-icons/fa";
 import { FcGoogle as GoogleIcon } from "react-icons/fc";
 
+import { TriangleAlertIcon } from "lucide-react";
+
 export const SignInCard = () => {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const params = useSearchParams();
+  const error = params.get("error");
+
+  const onCredentialSignIn = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    startTransition(async () => {
+      await signIn("credentials", {
+        email: email,
+        password: password,
+        redirectTo: "/",
+      });
+    });
+  };
+
   const onProviderSignIn = (provider: "github" | "google") => {
-    signIn(provider, { redirectTo: "/" });
+    startTransition(async () => {
+      await signIn(provider, { redirect: false });
+    });
   };
 
   return (
@@ -29,13 +56,56 @@ export const SignInCard = () => {
         </CardDescription>
       </CardHeader>
 
+      {!!error && (
+        <div className="mb-6 flex items-center gap-x-2 rounded-md bg-destructive/15 p-3 text-sm text-destructive">
+          <TriangleAlertIcon className="size-4 min-w-4" />
+          {error === "OAuthAccountNotLinked" ? (
+            <p>Another account already exists with the same e-mail address</p>
+          ) : (
+            <p>Invalid email or password</p>
+          )}
+        </div>
+      )}
+
       <CardContent className="space-y-5 px-0 pb-0">
+        <form onSubmit={onCredentialSignIn} className="space-y-2.5">
+          <Input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="Email"
+            disabled={isPending}
+            required
+          />
+          <Input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder="Password"
+            disabled={isPending}
+            required
+            minLength={3}
+            maxLength={20}
+          />
+          <Button
+            type="submit"
+            className="w-full"
+            size="lg"
+            disabled={isPending}
+          >
+            Continue
+          </Button>
+        </form>
+
+        <Separator />
+
         <div className="flex flex-col gap-y-2.5">
           <Button
             variant="outline"
             size="lg"
             className="relative w-full font-semibold [&_svg]:size-5"
             onClick={() => onProviderSignIn("google")}
+            disabled={isPending}
           >
             <GoogleIcon className="absolute left-2.5 top-2.5 mr-2" />
             Continue with Google
@@ -45,6 +115,7 @@ export const SignInCard = () => {
             size="lg"
             className="relative w-full font-semibold [&_svg]:size-5"
             onClick={() => onProviderSignIn("github")}
+            disabled={isPending}
           >
             <GithubIcon className="absolute left-2.5 top-2.5 mr-2" />
             Continue with Github
@@ -52,7 +123,13 @@ export const SignInCard = () => {
         </div>
         <p className="text-xs text-muted-foreground">
           Don&apos;t have an account?
-          <Button variant="link" size="sm" asChild className="text-sky-700">
+          <Button
+            variant="link"
+            size="sm"
+            asChild
+            className="text-sky-700"
+            disabled={isPending}
+          >
             <Link href="/sign-up">Sign up</Link>
           </Button>
         </p>

--- a/src/features/auth/components/sign-up-card.tsx
+++ b/src/features/auth/components/sign-up-card.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { signIn } from "next-auth/react";
+
+import { useSignUp } from "@/features/auth/hooks/use-sign-up";
 
 import {
   Card,
@@ -10,14 +13,43 @@ import {
   CardDescription,
   CardContent,
 } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 
 import { FaGithub as GithubIcon } from "react-icons/fa";
 import { FcGoogle as GoogleIcon } from "react-icons/fc";
+import { TriangleAlertIcon } from "lucide-react";
 
 export const SignUpCard = () => {
+  const mutation = useSignUp();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
   const onProviderSignUp = (provider: "github" | "google") => {
     signIn(provider, { redirectTo: "/" });
+  };
+
+  const onCredentialSignUp = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    mutation.mutate(
+      {
+        name,
+        email,
+        password,
+      },
+      {
+        onSuccess: () => {
+          signIn("credentials", {
+            email,
+            password,
+            redirectTo: "/",
+          });
+        },
+      },
+    );
   };
 
   return (
@@ -29,13 +61,58 @@ export const SignUpCard = () => {
         </CardDescription>
       </CardHeader>
 
+      {!!mutation.error && (
+        <div className="mb-6 flex items-center gap-x-2 rounded-md bg-destructive/15 p-3 text-sm text-destructive">
+          <TriangleAlertIcon className="size-4" />
+          <p>{mutation.error.message}</p>
+        </div>
+      )}
+
       <CardContent className="space-y-5 px-0 pb-0">
+        <form onSubmit={onCredentialSignUp} className="space-y-2.5">
+          <Input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Full name"
+            disabled={mutation.isPending}
+            required
+          />
+          <Input
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="Email"
+            disabled={mutation.isPending}
+            required
+          />
+          <Input
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            placeholder="Password"
+            disabled={mutation.isPending}
+            required
+          />
+          <Button
+            type="submit"
+            className="w-full"
+            size="lg"
+            disabled={mutation.isPending}
+          >
+            Continue
+          </Button>
+        </form>
+
+        <Separator />
+
         <div className="flex flex-col gap-y-2.5">
           <Button
             variant="outline"
             size="lg"
             className="relative w-full font-semibold [&_svg]:size-5"
             onClick={() => onProviderSignUp("google")}
+            disabled={mutation.isPending}
           >
             <GoogleIcon className="absolute left-2.5 top-2.5 mr-2" />
             Continue with Google
@@ -45,6 +122,7 @@ export const SignUpCard = () => {
             size="lg"
             className="relative w-full font-semibold [&_svg]:size-5"
             onClick={() => onProviderSignUp("github")}
+            disabled={mutation.isPending}
           >
             <GithubIcon className="absolute left-2.5 top-2.5 mr-2" />
             Continue with Github
@@ -52,7 +130,13 @@ export const SignUpCard = () => {
         </div>
         <p className="text-xs text-muted-foreground">
           Already have an account?
-          <Button variant="link" size="sm" asChild className="text-sky-700">
+          <Button
+            variant="link"
+            size="sm"
+            className="text-sky-700"
+            disabled={mutation.isPending}
+            asChild
+          >
             <Link href="/sign-in">Sign in</Link>
           </Button>
         </p>

--- a/src/features/auth/hooks/use-sign-up.ts
+++ b/src/features/auth/hooks/use-sign-up.ts
@@ -1,0 +1,33 @@
+import { useMutation } from "@tanstack/react-query";
+import { InferRequestType, InferResponseType } from "hono";
+
+import { client } from "@/lib/hono";
+import { toast } from "sonner";
+
+// /api/users의 POST요청타입
+type ResponseType = InferResponseType<(typeof client.api.users)["$post"]>;
+type RequestType = InferRequestType<(typeof client.api.users)["$post"]>["json"];
+
+// Error는 기본 Native Error 타입
+export const useSignUp = () => {
+  const mutation = useMutation<ResponseType, Error, RequestType>({
+    mutationFn: async (json) => {
+      const response = await client.api.users.$post({ json });
+
+      if (!response.ok) {
+        const errorJson = await response.json();
+        throw new Error(`${errorJson.error}`);
+      }
+
+      return await response.json();
+    },
+    onError: (error) => {
+      toast.error(`${error.message}`, { id: "error" });
+    },
+    onSuccess: () => {
+      toast.success("User created", { id: "success" });
+    },
+  });
+
+  return mutation;
+};


### PR DESCRIPTION
## 회원가입
### 작업 내역
- [x] 이메일/이름/비밀번호 입력 폼 추가
- [x] session strategy 를 JWT 로 변경 ( Auth.js Credential 은 JWT 방식만 가능 )
- [x] User 스키마에 password 추가
- [x] 이메일이 중복이면 에러처리
- [x] 비밀번호 암호화
- [x] 이메일 / 비밀번호 검증 코드추가

### 화면
![Image](https://github.com/user-attachments/assets/37d07e93-6cae-42cb-9e3d-83bfddb8c228)

<br/>

## 로그인
### 작업 내역
- [x] auth.ts 에 Credential Login 을 위한 코드 추가
- [x] 이메일/비밀번호 입력 폼 추가
- [x] 에러메세지 추가
### 화면
![Image](https://github.com/user-attachments/assets/902e8a7d-949a-48c9-b254-8bd18611cb3e)