### PR TITLE
메인페이지 프로젝트 리스트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bcryptjs": "^3.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
     "drizzle-orm": "^0.39.3",
     "drizzle-zod": "^0.7.0",
     "fabric": "5.3.0-browser",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       drizzle-orm:
         specifier: ^0.39.3
         version: 0.39.3(@neondatabase/serverless@0.10.4)(@types/pg@8.11.6)
@@ -1667,6 +1670,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -4759,6 +4765,8 @@ snapshots:
       call-bound: 1.0.3
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.1.0: {}
 
   debug@3.2.7:
     dependencies:

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,5 +1,6 @@
 import { protectServer } from "@/features/auth/utils";
 import { Banner } from "./banner";
+import { ProjectsSection } from "./projects-section";
 
 export default async function Home() {
   await protectServer();
@@ -7,6 +8,7 @@ export default async function Home() {
   return (
     <div className="mx-auto flex max-w-screen-2xl flex-col space-y-6 pb-10">
       <Banner />
+      <ProjectsSection />
     </div>
   );
 }

--- a/src/app/(dashboard)/projects-section.tsx
+++ b/src/app/(dashboard)/projects-section.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import React from "react";
+import { ko } from "date-fns/locale";
+import { useRouter } from "next/navigation";
+import { formatDistanceToNow } from "date-fns";
+
+import { useGetProjects } from "@/features/projects/api/use-get-projects";
+
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+
+import {
+  AlertTriangleIcon,
+  CopyIcon,
+  FileIcon,
+  LoaderIcon,
+  MoreHorizontalIcon,
+  SearchIcon,
+  TrashIcon,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export const ProjectsSection = () => {
+  const router = useRouter();
+
+  const { data, status, fetchNextPage, isFetchingNextPage, hasNextPage } =
+    useGetProjects();
+
+  if (status === "pending") {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold">Recent projects</h3>
+        <div className="jutify-center flex h-32 flex-col items-center gap-y-4">
+          <LoaderIcon className="size-6 animate-spin text-muted-foreground" />
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold">Recent projects</h3>
+        <div className="jutify-center flex h-32 flex-col items-center gap-y-4">
+          <AlertTriangleIcon className="size-6 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">
+            Failed to load projects
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data.pages.length) {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold">Recent projects</h3>
+        <div className="jutify-center flex h-32 flex-col items-center gap-y-4">
+          <SearchIcon className="size-6 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">No projects found</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold">Recent projects</h3>
+      <Table>
+        <TableBody>
+          {data.pages.map((group, index) => (
+            <React.Fragment key={index}>
+              {group.data.map((project) => (
+                <TableRow key={project.id}>
+                  <TableCell
+                    className="flex cursor-pointer items-center gap-x-2 font-medium"
+                    onClick={() => router.push(`editor/${project.id}`)}
+                  >
+                    <FileIcon className="size-6" />
+                    {project.name}
+                  </TableCell>
+
+                  <TableCell
+                    className="hidden cursor-pointer md:table-cell"
+                    onClick={() => router.push(`editor/${project.id}`)}
+                  >
+                    {project.width} x {project.height} px
+                  </TableCell>
+
+                  <TableCell
+                    className="hidden cursor-pointer md:table-cell"
+                    onClick={() => router.push(`editor/${project.id}`)}
+                  >
+                    {formatDistanceToNow(project.updatedAt, {
+                      addSuffix: true,
+                      locale: ko,
+                    })}
+                  </TableCell>
+
+                  <TableCell className="flex items-center justify-end">
+                    <DropdownMenu modal={false}>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="[&_svg]:size-4"
+                          disabled={false}
+                        >
+                          <MoreHorizontalIcon />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="w-60" align="end">
+                        <DropdownMenuItem
+                          className="h-10 cursor-pointer [&_svg]:size-4"
+                          disabled={false}
+                          onClick={() => {}}
+                        >
+                          <CopyIcon className="mr-2" />
+                          <span>Make a copy</span>
+                        </DropdownMenuItem>
+
+                        <DropdownMenuItem
+                          className="h-10 cursor-pointer [&_svg]:size-4"
+                          disabled={false}
+                          onClick={() => {}}
+                        >
+                          <TrashIcon className="mr-2" />
+                          <span>Delete</span>
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </React.Fragment>
+          ))}
+        </TableBody>
+      </Table>
+      {hasNextPage && (
+        <div className="jusitfy-center flex w-full items-center pt-4">
+          <Button
+            variant="ghost"
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+          >
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/features/projects/api/use-create-project.ts
+++ b/src/features/projects/api/use-create-project.ts
@@ -1,5 +1,5 @@
 import { toast } from "sonner";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { InferRequestType, InferResponseType } from "hono";
 
 import { client } from "@/lib/hono";
@@ -15,6 +15,8 @@ type RequestType = InferRequestType<
 
 // Error는 기본 Native Error 타입
 export const useCreateProject = () => {
+  const queryClient = useQueryClient();
+
   const mutation = useMutation<ResponseType, Error, RequestType>({
     mutationFn: async (json) => {
       const response = await client.api.projects.$post({ json });
@@ -28,7 +30,7 @@ export const useCreateProject = () => {
     onSuccess: () => {
       toast.success("Project created", { id: "success" });
 
-      // TODO: Invalidate "projects" query
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
     },
     onError: () => {
       toast.error("Failed to create project", { id: "error" });

--- a/src/features/projects/api/use-get-projects.ts
+++ b/src/features/projects/api/use-get-projects.ts
@@ -1,0 +1,36 @@
+import { InferResponseType } from "hono";
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { client } from "@/lib/hono";
+
+// 성공시 반환되는 타입
+export type ResponseType = InferResponseType<
+  (typeof client.api.projects)["$get"],
+  200
+>;
+
+export const useGetProjects = () => {
+  const query = useInfiniteQuery<ResponseType, Error>({
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+    queryKey: ["projects"],
+    queryFn: async ({ pageParam }) => {
+      // Client에서 Query는 String으로 넘겨야 합니다.
+      // Server에서 Coerce를 통해 Number로 변환합니다.
+      const response = await client.api.projects.$get({
+        query: {
+          page: (pageParam as number).toString(),
+          limit: "5",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch project");
+      }
+
+      return response.json();
+    },
+  });
+
+  return query;
+};

--- a/src/features/projects/api/use-update-project.ts
+++ b/src/features/projects/api/use-update-project.ts
@@ -31,7 +31,7 @@ export const useUpdateProject = (id: string) => {
       return await response.json();
     },
     onSuccess: () => {
-      // TODO: Invalidate "projects" query
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
       queryClient.invalidateQueries({ queryKey: ["project", { id }] });
     },
     onError: () => {


### PR DESCRIPTION
## 프로젝트 리스트 추가
### 화면
![Image](https://github.com/user-attachments/assets/93ab5b93-9538-476f-9f0a-5bac5ed2d26c)

### 작업 내역
- [x] project 리스트를 불러올 API 추가
- [x] 최근 5개 프로젝트를 보여주도록 퍼블리싱
- [x] 더보기 버튼 클릭 시 프로젝트를 더 보여주도록 기능 구현
- [x] `date-fns`의 `formatDistanceToNow`메서드를 통해 update된 시간이 출력되도록 기능 구현

```tsx
formatDistanceToNow(project.updatedAt, {
    addSuffix: true,
    locale: ko,
})
```

### 라이브러리 추가
```shell
pnpm add date-fns
```