### PR TITLE
에디터 템플릿 사이드바 기능구현

### DIFF
--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -19,6 +19,7 @@ import { ShapeSidebar } from "@/features/editor/components/shape-sidebar";
 import { ImageSidebar } from "@/features/editor/components/image-sidebar";
 import { FilterSidebar } from "@/features/editor/components/filter-sidebar";
 import { OpacitySidebar } from "@/features/editor/components/opacity-sidebar";
+import { TemplateSidebar } from "@/features/editor/components/template-sidebar";
 import { SettingsSidebar } from "@/features/editor/components/settings-sidebar";
 import { RemoveBgSidebar } from "@/features/editor/components/remove-bg-sidebar";
 import { FillColorSidebar } from "@/features/editor/components/fill-color-sidebar";
@@ -154,6 +155,12 @@ export const Editor = ({ initialData }: EditorProps) => {
         />
 
         <ImageSidebar
+          editor={editor}
+          activeTool={activeTool}
+          onChangeActiveTool={onChangeActiveTool}
+        />
+
+        <TemplateSidebar
           editor={editor}
           activeTool={activeTool}
           onChangeActiveTool={onChangeActiveTool}

--- a/src/features/editor/components/template-sidebar.tsx
+++ b/src/features/editor/components/template-sidebar.tsx
@@ -1,0 +1,112 @@
+import Image from "next/image";
+
+import { cn } from "@/lib/utils";
+
+import { ToolSidebarClose } from "@/features/editor/components/tool-sidebar-close";
+import { ToolSidebarHeader } from "@/features/editor/components/tool-sidebar-header";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+import { ActiveTool, Editor } from "@/features/editor/types";
+import { AlertTriangleIcon, LoaderIcon } from "lucide-react";
+import {
+  ResponseType,
+  useGetTemplates,
+} from "@/features/projects/api/use-get-templates";
+import { useConfirm } from "@/hooks/use-confirm";
+
+interface ImageSidebarProps {
+  editor: Editor | undefined;
+  activeTool: ActiveTool;
+  onChangeActiveTool: (tool: ActiveTool) => void;
+}
+
+export const TemplateSidebar = ({
+  editor,
+  activeTool,
+  onChangeActiveTool,
+}: ImageSidebarProps) => {
+  const [ConfirmDialog, confirm] = useConfirm(
+    "Are you sure?",
+    "You are about to replace the current project with this template.",
+  );
+
+  const { data, isLoading, isError } = useGetTemplates({
+    limit: "20",
+    page: "1",
+  });
+
+  const onClose = () => {
+    onChangeActiveTool("select");
+  };
+
+  const onClick = async (template: ResponseType["data"][0]) => {
+    // TODO: Check if template is pro
+    const ok = await confirm();
+    if (ok) {
+      editor?.loadJson(template.json);
+    }
+  };
+
+  return (
+    <aside
+      className={cn(
+        "relative z-[40] flex h-full w-[360px] flex-col border-r bg-white",
+        activeTool === "templates" ? "visible" : "hidden",
+      )}
+    >
+      <ConfirmDialog />
+      <ToolSidebarHeader
+        title="Templates"
+        description="Choose from a variety of templates to get started"
+      />
+
+      {isLoading && (
+        <div className="flex flex-1 items-center justify-center">
+          <LoaderIcon className="size-4 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {isError && (
+        <div className="flex flex-1 flex-col items-center justify-center gap-y-4">
+          <AlertTriangleIcon className="size-4 text-muted-foreground" />
+          <p className="text-xs text-muted-foreground">
+            Fail to fetch templates
+          </p>
+        </div>
+      )}
+
+      <ScrollArea>
+        <div className="p-4">
+          <div className="grid grid-cols-2 gap-4">
+            {data &&
+              data.map((template) => {
+                return (
+                  <button
+                    key={template.id}
+                    onClick={() => onClick(template)}
+                    className="group relative w-full overflow-hidden rounded-sm border bg-muted transition hover:opacity-75"
+                    style={{
+                      aspectRatio: `${template.width}/${template.height}`,
+                    }}
+                  >
+                    <Image
+                      fill
+                      src={template.thumbnailUrl ?? ""}
+                      alt={template.name ?? "Template"}
+                      className="object-cover"
+                    />
+                    <div className="absolute bottom-0 left-0 w-full truncate bg-black/50 p-1 text-left text-[10px] text-white opacity-0 transition group-hover:opacity-100">
+                      {template.name}
+                    </div>
+                  </button>
+                );
+              })}
+          </div>
+        </div>
+      </ScrollArea>
+
+      <ToolSidebarClose onClick={onClose} />
+    </aside>
+  );
+};


### PR DESCRIPTION
## 템플릿 사이드 바
### 화면
![Image](https://github.com/user-attachments/assets/793c8622-f692-4ad6-8f7c-c889313ab260)

### 작업 내역
- [x] 에디터에서 디자인 탭을 누르면 템플릿 사이드바 열리도록 기능 구현
- [x] 템플릿 사이드 바에서 템플릿 클릭 시 해당 템플릿이 적용되도록 기능 구현
- [x] 템플릿 사이드 바 퍼블리싱